### PR TITLE
move to using ast parser for import_function templatetag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# Editor files
+*.swp

--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ Examples:
 
 ### `import_function()`
 
-The `inport_function` function will search the source file and include only the specified function. If there are multiple functions with the same name in the source_file, only the first will be included (and you shouldn't have multiple functions with the same name anyway!).
+The `import_function` function searches a source file for the named function, class, class method or assigned variable. The function name supports dot-references, for example to get at the class method `area()` inside the class `Sqaure`, the function name would be "Square.area". To retrieve a nested function, name both the parent and child function, for example "outer.inner". 
+
+The first piece of code matching the given name is returned, (and you shouldn't have multiple things with the same name anyway!). The source file is parsed, not loaded, so no import side-effects take place.
 
 Whitespace following the function will not be included.
 
@@ -118,7 +120,7 @@ Examples:
 ```
 
 
-`MarkPlates` handles nested functions, included any functions nested in the specified function. The `language` and `filename` parameters are treated the same way they are in `import_source()`.
+The `language` and `filename` parameters are treated the same way they are in `import_source()`.
 
 ### `import_repl()`
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ MarkPlates is currently tested against Python 3.6, 3.7, 3.8, and 3.9.
 Running `markplates` is as simple as handing it a file:
 
 ```bash
-$ markplates [-c] template.mdt
+$ markplates template.mdt
 ```
 
-This will process the template in `template.mdt`, filling it in with data specified in the template. If the `-c` option is supplied, all but the first two lines of the output will be copied to the system clipboard. This is handy for copying the results to a website.
+This will process the template in `template.mdt`, filling it in with data specified in the template.
 
 The `examples` directory has the `simple.mdt` template:
 
@@ -34,12 +34,17 @@ The `examples` directory has the `simple.mdt` template:
 # Sample MarkPlates Template
 {{ set_path("./examples") }}
 
-This is an example of importing an entire file (minus the first line):
+This is an example of importing an entire file. Without a range specified, the first line is skipped to not include the shell specifier. Double blank lines are condensed into single lines:
 {{ import_source("testfile.py") }}
 
-While this silly example imports some of the lines from the file, demonstrating ranges:
-{{ import_source("testfile.py", [5, "2", 3, "8-$", ]) }}
+If you want to include the shell specifier, you can include it explicitly in a range. This silly example imports some of the lines from the file, demonstrating different ranges. Note that the ranges are compiled into a single list, so over-lapping ranges are only shown once:
+{{ import_source("testfile.py", [1, 5, "2", 3, "8-$", "$", "$-2"]) }}
 
+Functions can be imported from a file by name:
+
+{{ import_function("testfile.py", "flying_pig_menu") }}
+
+The import_repl tag captures stdout and stderr from a REPL session:
 {{ import_repl(
 """
 def func(x):
@@ -91,9 +96,9 @@ Examples:
 {{import_source("__main__.py")}} # includes all but line 1 from `__main__.py` file
 {{import_source("__main__.py", ["1-$",])}} # imports all lines from `__main__.py`
 {{import_source("__main__.py", [1, "3", "5-$"])}} # imports all lines except lines 2 and 4 from `__main__.py`
-{{import_source("__main__.py", language="python", filename=True)}}
-# includes all but line 1 from `__main__.py` file, puts the
-# contents in a python block with the filename as a comment in
+{{import_source("__main__.py", language="python", filename=True)}} 
+# includes all but line 1 from `__main__.py` file, puts the 
+# contents in a python block with the filename as a comment in 
 # the first line of the block.
 ```
 
@@ -102,7 +107,7 @@ Examples:
 
 ### `import_function()`
 
-The `import_function` function will search the source file and include only the specified function. If there are multiple functions with the same name in the source_file, only the first will be included (and you shouldn't have multiple functions with the same name anyway!).
+The `inport_function` function will search the source file and include only the specified function. If there are multiple functions with the same name in the source_file, only the first will be included (and you shouldn't have multiple functions with the same name anyway!).
 
 Whitespace following the function will not be included.
 
@@ -157,6 +162,10 @@ Line number ranges allow you to specify which lines you want to include from the
 
 * "10-$" : an unlimited range includes start line to the end of the file
 
+* "$" : the last line
+
+* "$-3" : negative indexing, the last line and the three lines that proceed it
+
 > **Note:** LINE NUMBERING STARTS AT 1!
 
 ## Features to Come
@@ -164,7 +173,6 @@ Line number ranges allow you to specify which lines you want to include from the
 I'd like to add:
 
 * Capturing the results of a shell command and inserting into the file
-* Copying the resultant Markdown file to the clipboard
 * Running `black` over the included Python source
 * Windows and Mac testing/support
 

--- a/README.mdt
+++ b/README.mdt
@@ -86,7 +86,9 @@ Examples:
 
 ### `import_function()`
 
-The `inport_function` function will search the source file and include only the specified function. If there are multiple functions with the same name in the source_file, only the first will be included (and you shouldn't have multiple functions with the same name anyway!).
+The `import_function` function searches a source file for the named function, class, class method or assigned variable. The function name supports dot-references, for example to get at the class method `area()` inside the class `Sqaure`, the function name would be "Square.area". To retrieve a nested function, name both the parent and child function, for example "outer.inner". 
+
+The first piece of code matching the given name is returned, (and you shouldn't have multiple things with the same name anyway!). The source file is parsed, not loaded, so no import side-effects take place.
 
 Whitespace following the function will not be included.
 
@@ -97,7 +99,7 @@ Examples:
 ```
 ' }}
 
-`MarkPlates` handles nested functions, included any functions nested in the specified function. The `language` and `filename` parameters are treated the same way they are in `import_source()`.
+The `language` and `filename` parameters are treated the same way they are in `import_source()`.
 
 ### `import_repl()`
 

--- a/README.mdt
+++ b/README.mdt
@@ -141,6 +141,10 @@ Line number ranges allow you to specify which lines you want to include from the
 
 * "10-$" : an unlimited range includes start line to the end of the file
 
+* "$" : the last line
+
+* "$-3" : negative indexing, the last line and the three lines that proceed it
+
 > **Note:** LINE NUMBERING STARTS AT 1!
 
 ## Features to Come
@@ -148,7 +152,6 @@ Line number ranges allow you to specify which lines you want to include from the
 I'd like to add:
 
 * Capturing the results of a shell command and inserting into the file
-* Copying the resultant Markdown file to the clipboard
 * Running `black` over the included Python source
 * Windows and Mac testing/support
 

--- a/examples/simple.mdt
+++ b/examples/simple.mdt
@@ -1,12 +1,17 @@
 # Sample MarkPlates Template
 {{ set_path("./examples") }}
 
-This is an example of importing an entire file (minus the first line):
+This is an example of importing an entire file. Without a range specified, the first line is skipped to not include the shell specifier. Double blank lines are condensed into single lines:
 {{ import_source("testfile.py") }}
 
-While this silly example imports some of the lines from the file, demonstrating ranges:
-{{ import_source("testfile.py", [5, "2", 3, "8-$", ]) }}
+If you want to include the shell specifier, you can include it explicitly in a range. This silly example imports some of the lines from the file, demonstrating different ranges. Note that the ranges are compiled into a single list, so over-lapping ranges are only shown once:
+{{ import_source("testfile.py", [1, 5, "2", 3, "8-$", "$", "$-2"]) }}
 
+Functions can be imported from a file by name:
+
+{{ import_function("testfile.py", "flying_pig_menu") }}
+
+The import_repl tag captures stdout and stderr from a REPL session:
 {{ import_repl(
 """
 def func(x):
@@ -15,3 +20,4 @@ def func(x):
 
 func(True)
 func(False) """) }}
+

--- a/examples/testfile.py
+++ b/examples/testfile.py
@@ -1,13 +1,13 @@
-1
-2
-3
-4
-5
-6
-7
-8
-9
-10
-11
-12
-13
+#!/usr/bin/env python
+
+def flying_pig_menu():
+    components = ["SPAM", "BAKED BEANS"]
+    menu_item = [component[0] for component in range(0, 6)]
+    menu_item.append(components[1])
+
+    menu_string = ",".join(menu_item) + f"+{component[1]"
+    return menu_string
+
+
+print("Hello world")
+print("Vikings love:", viking_menu)

--- a/markplates/__main__.py
+++ b/markplates/__main__.py
@@ -224,13 +224,12 @@ def process_template(template):
 
 @click.command(context_settings=dict(help_option_names=["-h", "--help"]))
 @click.option(
-    "-v", "--verbose", type=bool, default=False, help="Verbose debugging info"
+    "-v", "--verbose", is_flag=True, help="Verbose debugging info"
 )
 @click.option(
     "-c",
     "--clip",
-    type=bool,
-    default=False,
+    is_flag=True,
     help="RealPython output to clipboard",
 )
 @click.argument("template", type=str)

--- a/markplates/__main__.py
+++ b/markplates/__main__.py
@@ -189,16 +189,30 @@ def condense_ranges(input_lines, ranges):
             rint = int(_range)
             output_numbers.add(rint)
         except ValueError:
-            # If it's not a single line, look for a range
-            start, end = _range.split("-")
-            start = int(start)
-            # check for $ on end first
-            if end.strip() == "$":
-                end = len(input_lines)
+            if _range == "$":
+                # $ on its own means last line
+                output_numbers.add(len(input_lines))
             else:
-                end = int(end)
-            # output_numbers.update(list(range(start, end+1)))
-            output_numbers.update(range(start, end + 1))
+                # If it's not a single line, look for a range
+                start, end = _range.split("-")
+                if start == "$":
+                    # Support negative indexing on lines, end will be the last
+                    # line, start will be the last line minus the "end" value
+                    # in the range
+                    count = int(end)
+                    end = len(input_lines)
+                    start = end - count
+                else:
+                    # Start of range is a number
+                    start = int(start)
+                    # check for $ on end first
+                    if end.strip() == "$":
+                        end = len(input_lines)
+                    else:
+                        end = int(end)
+
+                # output_numbers.update(list(range(start, end+1)))
+                output_numbers.update(range(start, end + 1))
     # now we have normalized the line numbers, create the list of output lines
     output_lines = list()
     for number in sorted(output_numbers):

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     packages=[NAME],
     include_package_data=False,
     install_requires=[
+        "asttokens==2.0.4",
         "Click==7.1.2", 
         "Jinja2==2.11.2",
         "pyperclip==1.8.0",

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,10 @@ setup(
     ],
     packages=[NAME],
     include_package_data=False,
-    install_requires=["Click", "Jinja2"],
+    install_requires=[
+        "Click==7.1.2", 
+        "Jinja2==2.11.2",
+        "pyperclip==1.8.0",
+    ],
     entry_points={"console_scripts": ["markplates=markplates.__main__:main"]},
 )

--- a/tests/data/source.py
+++ b/tests/data/source.py
@@ -1,0 +1,18 @@
+class Square:
+    def __init__(self, side):
+        self.side = side
+
+    def area(self):
+        """Area of this square"""
+        return self.side * self.side
+
+
+def area(length, width):
+    """Badly named function returning the area of a rectangle"""
+    return length * width
+
+
+my_squares = [
+    Square(1, 1),
+    Square(2, 2),   # twice as much square
+]

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -28,6 +28,21 @@ def test_counting_range(counting_lines):
     output_lines = markplates.condense_ranges(lines, ranges)
     assert output_lines == ["8\n", "9\n", "10\n"]
 
+    # last line only
+    ranges = ["$"]
+    output_lines = markplates.condense_ranges(lines, ranges)
+    assert output_lines == ["13\n"]
+
+    # negative indexing, border condition
+    ranges = ["$-1"]
+    output_lines = markplates.condense_ranges(lines, ranges)
+    assert output_lines == ["12\n", "13\n"]
+
+    # negative indexing
+    ranges = ["$-3"]
+    output_lines = markplates.condense_ranges(lines, ranges)
+    assert output_lines == ["10\n", "11\n", "12\n", "13\n"]
+
 
 def test_spacing(counting_lines):
     lines = counting_lines()

--- a/tests/test_src.py
+++ b/tests/test_src.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from markplates.__main__ import find_in_source
+
+
+def test_find_source():
+    p = Path(__file__).resolve().parent / "data/source.py"
+    with open(p) as f:
+        source = f.read()
+
+    code = find_in_source(source, 'area')
+    assert "area of a rectangle" in code
+    assert code.count('\n') == 3
+
+    code = find_in_source(source, 'Square.area')
+    assert "Area of this square" in code
+    assert code.count('\n') == 3
+
+    code = find_in_source(source, 'my_squares')
+    assert "twice as much" in code
+    assert code.count('\n') == 4

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist = py36, py37, py38
 
 [testenv]
 deps =
+    asttokens
     click
     jinja2
     pytest


### PR DESCRIPTION
The import_function templatetag now uses the asttokens library to parse code from a file. 

Can now use dot notation and read functions, classes, methods and assigned variables. Naming works on the hierarchy found, so "Square.area.width" would be the width assignment in the area method of the Square class. Handles nested functions the same way.

I stripped out a whole bunch of the testing as it was there to test the regexes, I'm assuming that the standard library ast parser works :)  Added test code specific to the find_in_source() helper method, then modified the test_import_function script to just make sure the templatetag called the helper method correctly.