### PR TITLE
Add ability to change Jinja delimiter to [[ ]]

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,12 @@ Line number ranges allow you to specify which lines you want to include from the
 
 The `-c` option will copy most of the output to the clipboard.  The first two lines are skipped, which generally are the `h1` title and the following blank line.  This is done to simplify copying the output to the Real Python CMS system.
 
+### Square Brackets
+
+The `-s` / `--square` option tells the parser to use `[[` and `]]` as the
+function delimiters. Instead of ` {{ import_function("foo", "bar")
+}} `, use `[[ import_function("foo", "bar") ]]`.
+
 ## Features to Come
 
 I'd like to add:

--- a/README.mdt
+++ b/README.mdt
@@ -159,6 +159,12 @@ Line number ranges allow you to specify which lines you want to include from the
 
 The `-c` option will copy most of the output to the clipboard.  The first two lines are skipped, which generally are the `h1` title and the following blank line.  This is done to simplify copying the output to the Real Python CMS system.
 
+### Square Brackets
+
+The `-s` / `--square` option tells the parser to use `[[` and `]]` as the
+function delimiters. Instead of `{{ ' {{ import_function("foo", "bar")
+}} ' }}`, use `[[ import_function("foo", "bar") ]]`.
+
 ## Features to Come
 
 I'd like to add:

--- a/markplates/__main__.py
+++ b/markplates/__main__.py
@@ -264,13 +264,24 @@ def condense_ranges(input_lines, ranges, source_name):
     return output
 
 
-def process_template(template):
+def process_template(template, square):
     # alias the block start and stop strings as they conflict with the
     # templating on RealPython.  Currently these are unused here.
     file_loader = jinja2.FileSystemLoader(str(template.parent))
-    env = jinja2.Environment(
-        loader=file_loader, block_start_string="&&&&", block_end_string="&&&&"
-    )
+
+    kwargs = {
+        "loader":file_loader, 
+        "block_start_string":"&&&&", 
+        "block_end_string":"&&&&"
+    }
+
+    if square:
+        kwargs.update({
+            'variable_start_string':'[[',
+            'variable_end_string':']]',
+        })
+
+    env = jinja2.Environment(**kwargs)
     template = env.get_template(str(template.name))
 
     template_state = TemplateState()
@@ -285,10 +296,13 @@ def process_template(template):
 @click.option(
     "-c", "--clip", is_flag=True, help="RealPython output to clipboard"
 )
+@click.option(
+    "-s", "--square", is_flag=True, help="Use [[ ]] for template tags"
+)
 @click.argument("template", type=str)
-def main(verbose, clip, template):
+def main(verbose, clip, square, template):
     try:
-        output = process_template(pathlib.Path(template))
+        output = process_template(pathlib.Path(template), square)
         print(output)
         sys.stdout.flush()
         if clip:


### PR DESCRIPTION
Been writing an article on Django templates, had a lot of {% and {{ in the article. Added feature to markplates to change the  function indicators to [[ and ]] through "--sqaure" on the command line.